### PR TITLE
Fix corrupted macOS release bundles without Developer ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ tmp/
 
 # electron-builder trial/override configs
 electron-builder.trial.yml
-electron-builder.x64.yml
 dev-app-update.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS first-launch override**: release bundles are now completely ad-hoc signed, preserving Gatekeeper's user-override flow instead of being rejected as a corrupted bundle when no Developer ID certificate is available.
+
 ## [0.8.3] - 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Releases are published **only** from this repo, to [`github.com/nornzach/oh-my-p
 2. Bump `version` in `package.json`, write the `CHANGELOG.md` section, update the Install links above.
 3. `bunx vitest run && bun run check:types && bun run build`.
 4. `bun run build:omp && bun run build:omp:x64` — smoke-test each binary (`resources/omp --smoke-test`, or launch with `--mode rpc-ui` and expect `{"type":"ready"}`).
-5. `bun run package:mac:arm64 -- --publish never` and `bun run package:mac:x64 -- --publish never`; mount both DMGs, verify the bundled sidecar is the matching arch (`file …/Contents/Resources/omp`), launch each app once (sidecar `ready`, settings toggle persists).
+5. `bun run package:mac:arm64 -- --publish never` and `bun run package:mac:x64 -- --publish never`; verify both app bundles are sealed (`codesign --verify --deep --strict --verbose=2 <path-to-omp.app>`), mount both DMGs, verify the bundled sidecar is the matching arch (`file …/Contents/Resources/omp`), and launch each app once (sidecar `ready`, settings toggle persists).
 6. Commit, tag `vX.Y.Z`, push `main` + tag, publish the GitHub Release with both DMGs and the changelog body.
 
 ---

--- a/electron-builder.x64.yml
+++ b/electron-builder.x64.yml
@@ -1,0 +1,49 @@
+appId: sh.omp.gui
+productName: omp
+directories:
+  buildResources: resources
+  output: dist
+files:
+  - out/**/*
+  - "!node_modules/**/*"
+extraResources:
+  - from: resources/omp.x64
+    to: omp
+asar: true
+compression: maximum
+
+mac:
+  category: public.app-category.developer-tools
+  icon: resources/icon.icns
+  # Seal the complete bundle even when no Developer ID certificate is available.
+  # This preserves macOS's user-override flow instead of presenting the app as damaged.
+  identity: "-"
+  target:
+    - target: dmg
+      arch: [x64]
+    - target: zip
+      arch: [x64]
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: resources/entitlements.mac.plist
+  entitlementsInherit: resources/entitlements.mac.plist
+  extendInfo:
+    NSMicrophoneUsageDescription: omp uses the microphone for voice dictation in the composer.
+  notarize: false
+
+dmg:
+  contents:
+    - x: 130
+      y: 220
+    - x: 410
+      y: 220
+      type: link
+      path: /Applications
+
+publish:
+  provider: github
+  owner: nornzach
+  repo: oh-my-pi-gui
+
+electronLanguages:
+  - en

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -15,6 +15,9 @@ compression: maximum
 mac:
   category: public.app-category.developer-tools
   icon: resources/icon.icns
+  # Seal the complete bundle even when no Developer ID certificate is available.
+  # This preserves macOS's user-override flow instead of presenting the app as damaged.
+  identity: "-"
   target:
     # arm64 only here — x64 builds go through electron-builder.x64.yml, which
     # points extraResources at the x86_64 sidecar (resources/omp.x64) instead of

--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -8,6 +8,9 @@
 	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
+	<!-- Required when the complete Electron bundle is ad-hoc signed. -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 	<key>com.apple.security.audio-input</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## Problem

The macOS 0.8.3 release bundle fails strict code-signature validation:

```text
code has no resources but signature indicates they must be present
```

Gatekeeper consequently presents the app as damaged/corrupted rather than following the normal override flow documented in the README. This is the first-install portion of #1.

## Change

- Ad-hoc sign the complete macOS app bundle with `mac.identity: "-"`.
- Add `com.apple.security.cs.disable-library-validation`, required when combining ad-hoc signing with Hardened Runtime.
- Add strict deep signature verification to the release checklist.
- Document the correction in the changelog.

## User impact and limitation

This fixes the **damaged/corrupted app** problem by producing a structurally valid, sealed bundle. It does **not** provide Apple trust or notarization. On first launch, users must still manually approve the app through **System Settings → Privacy & Security → Open Anyway** (or use the documented right-click → Open flow).

This also does **not** fix automatic updates. A stable Apple Developer ID signature is still required for Squirrel.Mac / ShipIt to replace an installed bundle safely. That remaining limitation is tracked in #1.

## Verification

The released 0.8.3 ZIP fails:

```bash
codesign --verify --deep --strict --verbose=2 omp.app
# code has no resources but signature indicates they must be present
```

A rebuilt ZIP with this patch, after applying quarantine metadata and extracting it, passes:

```text
omp.app: valid on disk
omp.app: satisfies its Designated Requirement
```

`syspolicyd` then records the expected user-override prompt for bundle ID `sh.omp.gui`, rather than rejecting a malformed signature. The app remains ad-hoc signed and unnotarized by design.