### PR TITLE
Fix fast mode selected indicator

### DIFF
--- a/src/renderer/components/layout/InputArea.queue-shorthand.test.tsx
+++ b/src/renderer/components/layout/InputArea.queue-shorthand.test.tsx
@@ -348,6 +348,17 @@ describe("InputArea run settings", () => {
 		expect(buttonWithText("Modes")).toBeDefined();
 	});
 
+	it("marks fast mode selected when enabled but unavailable to the active model", async () => {
+		useModelStore.setState({ fastModeEnabled: true, fastModeActive: false });
+		await mount();
+
+		const fast = buttonWithText("Fast");
+		if (!fast) throw new Error("fast mode trigger missing");
+		const button = fast as unknown as HTMLElement;
+		expect(button.getAttribute("aria-pressed")).toBe("true");
+		expect(button.className).toContain("text-[var(--omp-accent)]");
+	});
+
 	it("lets a nested thinking portal dispatch before the parent menu dismisses", async () => {
 		await mountCompact();
 		await openRunSettings();

--- a/src/renderer/components/layout/InputArea.tsx
+++ b/src/renderer/components/layout/InputArea.tsx
@@ -1000,12 +1000,13 @@ function FastModeControl({ menuItem = false }: { menuItem?: boolean }) {
 		<button
 			type="button"
 			role={menuItem ? "menuitem" : undefined}
+			aria-pressed={enabled}
 			onClick={() => void useModelStore.getState().toggleFastMode()}
 			title={`${enabled ? t("input.fast.on") : t("input.fast.off")}${active ? t("input.fast.active") : ""}`}
 			className={cx(
 				"omp-pressable flex h-8 items-center gap-1.5 rounded-lg px-2 text-omp-md font-medium hover:bg-[var(--omp-selected-bg)]",
 				menuItem && "w-full",
-				active ? "text-[var(--omp-accent)]" : "text-[var(--omp-muted)]",
+				enabled ? "text-[var(--omp-accent)]" : "text-[var(--omp-muted)]",
 			)}
 		>
 			<Zap size={14} fill={active ? "currentColor" : "none"} />


### PR DESCRIPTION
## Problem

The Fast composer control styled its selected state from `fastModeActive`, which means priority service is realized by the current model. When Fast is enabled but unavailable to the active model, the tooltip says it is on while the control remains visually muted.

## Change

- Style the control from `fastModeEnabled`, matching the toggle state.
- Keep the lightning fill tied to `fastModeActive`, preserving the distinction between enabled and realized.
- Expose the toggle state through `aria-pressed`.
- Cover the enabled-but-inactive case with a regression test.

## Verification

- `bunx vitest run src/renderer/components/layout/InputArea.queue-shorthand.test.tsx`
- `bun run check:types`
- `bun run build`
- Verified the selected state in an isolated built GUI with `gpt-5.6-sol`.